### PR TITLE
Fix typos

### DIFF
--- a/doc_source/join-chime-meeting.md
+++ b/doc_source/join-chime-meeting.md
@@ -10,7 +10,7 @@ You can't run this action on a bridged call\.
     "Type": "JoinChimeMeeting",
     "Parameters": {
         "JoinToken": "meeting-attendee-join-token",
-        "CallId": "call-id-1"
+        "CallId": "call-id-1",
         "ParticipantTag": "LEG-A"
     }
 }
@@ -45,7 +45,7 @@ The SIP media application always invokes a Lambda function after running this ac
         "Type": "JoinChimeMeeting",
         "Parameters": {
             "JoinToken": "meeting-attendee-join-token",
-            "CallId": "call-id-1"
+            "CallId": "call-id-1",
             "ParticipantTag": "LEG-A"
         }
     }

--- a/doc_source/pause.md
+++ b/doc_source/pause.md
@@ -8,7 +8,7 @@ Pause a call for a specified time\.
     "Parameters": {
         "CallId": "call-id-1",
         "ParticipantTag": "LEG-A",
-        "DurationInMilliSeconds": "3000"
+        "DurationInMilliseconds": "3000"
     }
 }
 ```
@@ -25,7 +25,7 @@ Pause a call for a specified time\.
 *Required* – No  
 *Default value* – `ParticipantTag` of the invoked `callLeg` Ignored if you specify `CallId`
 
-**DurationInMilliSeconds**  
+**DurationInMilliseconds**  
 *Description* – Duration of the pause, in milliseconds  
 *Allowed values* – An integer >0  
 *Required* – Yes  


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

- join-chime-meeting.md - Added comma to fix JSON rendering
- pause.md - Fixed error, "DurationInMilliSeconds" -> "DurationInMilliseconds"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
